### PR TITLE
Remove no sources error

### DIFF
--- a/flatpak_builder_lint/checks/modules.py
+++ b/flatpak_builder_lint/checks/modules.py
@@ -62,8 +62,6 @@ class ModuleCheck(Check):
             for source in sources:
                 if name := module.get("name"):
                     self.check_source(name, source)
-        else:
-            self.errors.add(f"module-{name}-no-sources")
 
         if nested_modules := module.get("modules"):
             for nested_module in nested_modules:


### PR DESCRIPTION
After the [announcement on the forum](https://discourse.flathub.org/t/enforcing-pull-request-workflow-and-green-ci-status-of-prs/3109) I've tested this with my own man mnaifests. This specific error is thrown on every file generated with flatpak-pip-generator and also on valid modules like this, which uses the OpenJDK SDK Extension:
```yaml
  - name: openjdk17
    buildsystem: simple
    build-commands:
      - /usr/lib/sdk/openjdk17/install.sh
      - mkdir -p /app/jvm
      - mv /app/jre /app/jvm/openjdk17
      - ln -s /app/jvm/openjdk17/bin/java /app/bin/java
```
There are too many cases where this is valid, so this should neither be a error or a warning.