### PR TITLE
exceptions: Allow org.mozilla.Thunderbird to skip x11-and-wayland check

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1117,6 +1117,9 @@
     "org.kde.kdevelop": {
 	"finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "org.mozilla.Thunderbird": {
+        "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system"
+    },
     "org.octave.Octave": {
 	"finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
Thunderbird fallbacks to wayland when no X11 exist but otherwise prefer X11 when both are available on system.