### PR TITLE
Add RetroArch for wayland and x11 support

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1118,6 +1118,9 @@
     "org.kde.kdevelop": {
 	"finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "org.libretro.RetroArch": {
+        "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system"
+    },
     "org.mozilla.Thunderbird": {
         "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system"
     },


### PR DESCRIPTION
The org.libretro.RetroArch package will fallback to wayland on non-x11 platforms, so have the linting flag that as an exception.