### PR TITLE
appid code hosting exception for librewolf

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1074,6 +1074,9 @@
     "io.gitlab.Goodvibes": {
         "appid-code-hosting-too-few-components": "the app predates this linter rule"
     },
+    "io.gitlab.librewolf-community": {
+        "appid-code-hosting-too-few-components": "the app predates this linter rule"
+    },
     "io.howl.Editor": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
We'd like to add an exception for librewolf, until we can properly address renaming (and resubmitting) the application without breaking things on our end ^^