### PR TITLE
exceptions: Update reason for dolphin & kdevelop, add konsole & kate

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1157,10 +1157,10 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "org.kde.dolphin": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },
     "org.kde.kdevelop": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },
     "org.mozilla.Thunderbird": {
         "finish-args-contains-both-x11-and-wayland": "fallbacks to wayland on non-x11 system"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1159,7 +1159,13 @@
     "org.kde.dolphin": {
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },
+    "org.kde.kate": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
+    },
     "org.kde.kdevelop": {
+        "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
+    },
+    "org.kde.konsole": {
         "finish-args-flatpak-spawn-access": "required for host shell access via internal terminal"
     },
     "org.mozilla.Thunderbird": {

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1151,7 +1151,7 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "org.hydrogenmusic.Hydrogen": {
-        "flathub-json-skip-appstream-check": "appstream file has GPL license, upstream hasn't fixed it"  
+        "flathub-json-skip-appstream-check": "appstream file has GPL license, upstream hasn't fixed it"
     },
     "org.jabref.jabref": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
All three apps use flatpak-spawn to get hosts shell access for the internal built-in terminal emulator (Konsole KPart).