### PR TITLE
exceptions: Allow org.xfce.ristretto to skip dbus-access check

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1455,5 +1455,8 @@
     },
     "org.srb2.SRB2Kart": {
         "flathub-json-modified-publish-delay": "extra-data"
+    },
+    "org.xfce.ristretto": {
+        "finish-args-arbitrary-dbus-access": "https://github.com/flathub/flathub/issues/2770"
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/flathub/flathub/issues/2770#issuecomment-1290071440.