### PR TITLE
Let skip --enable-debug=no

### DIFF
--- a/flatpak_builder_lint/checks/modules.py
+++ b/flatpak_builder_lint/checks/modules.py
@@ -51,7 +51,7 @@ class ModuleCheck(Check):
                 for opt in config_opts:
                     if opt.startswith("--prefix="):
                         self.warnings.add(f"module-{name}-autotools-redundant-prefix")
-                    elif opt.startswith("--enable-debug"):
+                    elif opt.startswith("--enable-debug") and not opt.endswith("=no"):
                         self.errors.add(f"module-{name}-autotools-non-release-build")
 
         if buildsystem == "cmake":


### PR DESCRIPTION
We are erroring out when we find a --enable-debug but we don't check if it was a actually an explicit =no to actually avoid the debug symbols.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>