### PR TITLE
Allow spawn for de.mediathekview.MediathekView

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1473,5 +1473,8 @@
     },
     "io.github.hakandundar34coding.system-monitoring-center": {
         "finish-args-flatpak-spawn-access": "required for host shell access for getting system information such as processes, services, number of packages, etc."
+    },
+    "de.mediathekview.MediathekView": {
+        "finish-args-flatpak-spawn-access": "required to start VLC flatpak to view videos and live streams"
     }
 }


### PR DESCRIPTION
I'd like to add a flatpak for MediathekView which requires spawn access.  Updating these linter rules was suggested in <https://github.com/flathub/flathub/pull/3616#issuecomment-1297457910>, hence this MR.

`de.mediathekview.MediathekView` requires spawn access to launch the VLC flatpak which it uses VLC to view videos and livestreams.

