### PR TITLE
exceptions: allow Fightcade to modify publishing delay

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1282,6 +1282,9 @@
     "com.etlegacy.ETLegacy": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "com.fightcade.Fightcade": {
+        "flathub-json-modified-publish-delay": "Client version must be in sync with server to function"
+    },
     "com.flashforge.FlashPrint": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
The Fightcade client (distributed on Flathub) must be in sync with the server version to connect to the service.

See https://github.com/flathub/flatpak-builder-lint/issues/28#issuecomment-1302811364 for more details.