### PR TITLE
update exceptions for com.gitlab.newsflash

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -843,7 +843,8 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.gitlab.newsflash": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "appid-code-hosting-too-few-components": "app-id predates this linter rule"
     },
     "com.gitlab.sat_metalab.Splash": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"


### PR DESCRIPTION
It seems like `appid-code-hosting-too-few-components` was recently upgraded to throw an error. And now my flathub build failed:

https://github.com/flathub/com.gitlab.newsflash/pull/16

Do I have to wait for this to hit flathub to publish new releases?