### PR TITLE
Allow spawn for io.github.fsobolev.TimeSwitch

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1480,5 +1480,8 @@
     },
     "de.mediathekview.MediathekView": {
         "finish-args-flatpak-spawn-access": "required to start VLC flatpak to view videos and live streams"
+    },
+    "io.github.fsobolev.TimeSwitch": {
+        "finish-args-flatpak-spawn-access": "required to execute user-defined commands on the host"
     }
 }


### PR DESCRIPTION
[TimeSwitch](https://github.com/fsobolev/timeswitch) is the app that allows to perform various actions on a timer. In version 2022.11.12, ability to execute user-defined commands has been added, which requires spawn access (`--talk-name=org.freedesktop.Flatpak` has been added to the manifest). The users are warned that their commands will be executed outside of sandbox:

<img src="https://camo.githubusercontent.com/5a97ba8d3b4d2eebbf5caf94cf5448b2b017f7025d64f3feb4631431a20695b8/68747470733a2f2f692e696d6775722e636f6d2f4c436976394e652e706e67" width=300px>