### PR TITLE
Allow finish-args-unnecessary-xdg-data-access for jdMinecraftLauncher

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -817,7 +817,8 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
     "com.gitlab.JakobDev.jdMinecraftLauncher": {
-        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule",
+        "finish-args-unnecessary-xdg-data-access": "jdMinecraftLauncher creates .desktop files in share/applications"
     },
     "com.gitlab.jakobdev.jdnbtexplorer": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"


### PR DESCRIPTION
jdMinecraftLauncher needs this to create menu shortcuts in share/applications.