### PR TITLE
Allow exceptions for de.schmidhuberj.tubefeeder

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1486,5 +1486,9 @@
     },
     "io.github.fsobolev.TimeSwitch": {
         "finish-args-flatpak-spawn-access": "required to execute user-defined commands on the host"
+    },
+    "de.schmidhuberj.tubefeeder": {
+        "finish-args-flatpak-spawn-access": "Spawn arbitrary video player",
+        "finish-args-unnecessary-xdg-data-access": "the app predates this linter rule"
     }
 }


### PR DESCRIPTION
These exceptions are needed as:

- `finish-args-flatpak-spawn-access`: Spawn any arbitrary video players for videos. `xdg-open` will not work as these videos are passed per a URL, `xdg-open` would therefore always open the browser.
- `finish-args-unnecessary-xdg-data-access`: Data about subscriptions, watchlist, filters is stored there. This was done before that rule existed.