### PR TITLE
flatpak-manifest.schema: Fix the "test-commands"' value type checking

### DIFF
--- a/flatpak_builder_lint/staticfiles/flatpak-manifest.schema.json
+++ b/flatpak_builder_lint/staticfiles/flatpak-manifest.schema.json
@@ -436,7 +436,11 @@
         },
         "test-commands": {
           "description": "Array of commands to run during the tests.",
-          "type": "string"
+          "type": "array",
+          "items": {
+              "description": "Command to run during the tests.",
+              "type": "string"
+          }
         },
         "modules": {
           "description": "An array of objects specifying the modules to be built in order. String members in the array are interpreted as the name of a separate json or yaml file that contains a module.",


### PR DESCRIPTION
According to "test-commands"' description: "Array of commands to run during the tests.", it's value type should be an array of strings.

Fixes: https://github.com/flathub/flatpak-builder-lint/issues/94