### PR TITLE
Add spawn exception for com.unity.UnityHub

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1010,7 +1010,8 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "com.unity.UnityHub": {
-        "flathub-json-modified-publish-delay": "extra-data"
+        "flathub-json-modified-publish-delay": "extra-data",
+        "finish-args-flatpak-spawn-access": "needed to spawn the flatpaked version of vscode from the editor"
     },
     "com.visualstudio.code": {
         "flathub-json-modified-publish-delay": "extra-data",


### PR DESCRIPTION
Unity needs to be able to spawn the flatpaked version of VSCode from the Editor

See flathub/com.unity.UnityHub#77, flathub/com.unity.UnityHub#79, flathub/com.unity.UnityHub#80 and flathub/com.unity.UnityHub#82