### PR TITLE
Add exception for codes.merritt.Nyrna

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1512,5 +1512,8 @@
     },
     "com.helix_editor.Helix": {
         "finish-args-flatpak-spawn-access": "required to access language servers installed on host"
+    },
+    "codes.merritt.Nyrna": {
+        "finish-args-flatpak-spawn-access": "required to access and change process status on the host"
     }
 }


### PR DESCRIPTION
Nyrna requires the ability to read and change host process status for its core functionality.