### PR TITLE
Downgrade KDE status icon error to a warning

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -54,7 +54,7 @@ class FinishArgsCheck(Check):
 
         for own_name in fa["own-name"]:
             if own_name.startswith("org.kde.StatusNotifierItem"):
-                self.errors.add("finish-args-broken-kde-tray-permission")
+                self.warnings.add("finish-args-broken-kde-tray-permission")
 
             if appid:
                 # Values not allowed: appid or appid.*

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -62,7 +62,6 @@ def test_finish_args() -> None:
         "finish-args-arbitrary-autostart-access",
         "finish-args-arbitrary-dbus-access",
         "finish-args-arbitrary-xdg-data-access",
-        "finish-args-broken-kde-tray-permission",
         "finish-args-flatpak-spawn-access",
         "finish-args-incorrect-dbus-gvfs",
         "finish-args-redundant-home-and-host",
@@ -71,6 +70,7 @@ def test_finish_args() -> None:
     }
 
     warnings = {
+        "finish-args-broken-kde-tray-permission",
         "finish-args-contains-both-x11-and-wayland",
         "finish-args-deprecated-shm",
         "finish-args-x11-without-ipc",


### PR DESCRIPTION
Remedies the build bot breakage described in #66, which is currently an incentive to grant dangerously broad dbus permissions, and currently prevents that dangerous permission from being fixed in cases where it was deployed in the past.