### PR TITLE
Add exception for com.github.LongSoft.UEFITool

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -426,6 +426,9 @@
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "com.github.LongSoft.UEFITool": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
     "com.github.louis77.tuner": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },


### PR DESCRIPTION
Our app-id predates this linter rule.