### PR TITLE
exceptions: Add font-viewer

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1558,5 +1558,8 @@
     },
     "com.diffingo.fwbackups": {
         "finish-args-flatpak-spawn-access": "required to backup and restore installed packages"
+    },
+    "org.gnome.font-viewer": {
+        "finish-args-unnecessary-xdg-data-access": "required to save fonts"
     }
 }


### PR DESCRIPTION
The app requires the --filesystem=xdg-data/fonts:create permission to store/save fonts. This is a genuine usecase.