### PR TITLE
Add "finish-args-flatpak-spawn-access" exception for com.dec05eba.gpu_screen_recorder

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1583,5 +1583,8 @@
     },
     "io.github.mmstick.FontFinder": {
         "finish-args-unnecessary-xdg-data-access": "This program is designed to store font files in the font directory"
+    },
+    "com.dec05eba.gpu_screen_recorder": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn to capture a monitor on AMD/Intel GPUs"
     }
 }


### PR DESCRIPTION
The app requires flatpak-spawn to capture a monitor on AMD/Intel GPUs. It runs flatpak-spawn pkexec to run an external program as root (the program is part of the flatpak), because AMD/Intel requires root access to capture a monitor (KMS).

This is done to restrict root access to a very small executable that only does one thing (access to KMS), as opposed to running the whole flatpak (with network access) as root.