### PR TITLE
Add com.jetpackduba.Gitnuro exception

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -757,6 +757,9 @@
     "com.irccloud.desktop": {
         "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
     },
+    "com.jetpackduba.Gitnuro": {
+        "finish-args-flatpak-spawn-access": "required to access external terminal emulators and run external credentials managers for Git"
+    },
     "com.jgraph.drawio.desktop": {
         "appid-ends-with-lowercase-desktop": "app-id predates this linter rule"
     },


### PR DESCRIPTION
Add "finish-args-flatpak-spawn-access" exception to Gitnuro (Git client) to be able to start external terminal emulators & run external credentials managers for Git such as Git Credentials Managers (most common option but not the only possible one).

Related to https://github.com/flathub/com.jetpackduba.Gitnuro/pull/7 and https://github.com/JetpackDuba/Gitnuro/releases/tag/v1.2.0