### PR TITLE
Add appid-uses-code-hosting-domain exception for IP Lookup

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -160,6 +160,9 @@
     "com.github.bvschaik.julius": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },
+    "com.github.bytezz.IPLookup": {
+        "appid-uses-code-hosting-domain": "app-id predates this linter rule"
+    },
     "com.github.calo001.fondo": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"
     },


### PR DESCRIPTION
Needed for [com.github.bytezz.IPLookup](https://github.com/flathub/flathub/pull/4149)