### PR TITLE
Add org.fkoehler.KTailctl exception for access to flatpak-spawn.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1593,5 +1593,8 @@
     "page.codeberg.JakobDev.jdSimpleAutostart": {
         "finish-args-arbitrary-autostart-access": "the app predates this linter rule",
         "finish-args-unnecessary-xdg-config-access": "the app predates this linter rule"
+    },
+    "org.fkoehler.KTailctl": {
+        "finish-args-flatpak-spawn-access": "Needed to run the tailscale CLI tool outside which provides the information used by the App"
     }
 }


### PR DESCRIPTION
`org.fkoehler.KTailctl` fundamentally requires to run the Tailscale CLI tool in order to obtain information about the Tailscale status as well as controlling certain aspects of the client, e.g. connect/disconnect, sending/receiving files.