### PR TITLE
Update exceptions.json - add it.mijorus.gearlever

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1593,5 +1593,8 @@
     "page.codeberg.JakobDev.jdSimpleAutostart": {
         "finish-args-arbitrary-autostart-access": "the app predates this linter rule",
         "finish-args-unnecessary-xdg-config-access": "the app predates this linter rule"
+    },
+    "it.mijorus.gearlever": {
+        "finish-args-flatpak-spawn-access": "Required to launch AppImages that the user integrates into the system menu"
     }
 }


### PR DESCRIPTION
This app allows you to launch the appimages that the user "integrates" into the system menu.
The interface is designed to look like an app store (sort of), with big buttons to open or uninstall apps.

Before making a file executable, the app shows the md5 hash of the file and the user needs to manually check a label to mark the app as trusted.

This is all this permission it is used for.

PR for this app on Flathub:
https://github.com/flathub/flathub/pull/4214

Repo: 
https://github.com/mijorus/gearlever