### PR TITLE
Add exception for com.github.GradienceTeam.Gradience

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -305,7 +305,7 @@
     "com.github.GradienceTeam.Gradience": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
         "finish-args-unnecessary-xdg-data-access": "https://github.com/flathub/flathub/issues/3557",
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+        "finish-args-flatpak-spawn-access": "the app needs to change host gsettings to automatically select gnome shell theme"
     },
     "com.github.gyunaev.spivak": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -304,7 +304,8 @@
     },
     "com.github.GradienceTeam.Gradience": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule",
-        "finish-args-unnecessary-xdg-data-access": "https://github.com/flathub/flathub/issues/3557"
+        "finish-args-unnecessary-xdg-data-access": "https://github.com/flathub/flathub/issues/3557",
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "com.github.gyunaev.spivak": {
         "appid-uses-code-hosting-domain": "app-id predates this linter rule"


### PR DESCRIPTION
Gradience needs `finish-args-flatpak-spawn-access` for GNOME Shell theming feature to work properly, beta build fails because of this

Fixes https://github.com/flathub/com.github.GradienceTeam.Gradience/pull/13#issuecomment-1594677203