### PR TITLE
Allow flatpak spawn access for ecode.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1542,6 +1542,9 @@
     "com.helix_editor.Helix": {
         "finish-args-flatpak-spawn-access": "required to access language servers installed on host"
     },
+    "dev.ensoft.ecode": {
+        "finish-args-flatpak-spawn-access": "required to access language servers, linters and formatters installed on host"
+    },
     "codes.merritt.Nyrna": {
         "finish-args-flatpak-spawn-access": "required to access and change process status on the host"
     },


### PR DESCRIPTION
Hi, I'm the author of [ecode](https://github.com/SpartanJ/ecode) code editor. ecode uses language servers, linters and formatters binaries available on the system, I need flatpak spawn access to be able to use them. Thanks