### PR TITLE
Allow flatpak spawn access for io.github.nokse22.inspector

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1621,5 +1621,8 @@
     },
     "org.gnu.emacs": {
         "finish-args-flatpak-spawn-access": "required to access external tools since the Emacs ecosystem expects to lean heavily on them"
+    },
+    "io.github.nokse22.inspector": {
+        "finish-args-flatpak-spawn-access": "Neded to execute external commands to show informations about your computer"
     }
 }


### PR DESCRIPTION
The app is a wrapper for some useful commands that give information to the user about the system in an easy to read way. flatpak spawn access is needed to run commands like lsusb and cat /etc/os-release. This is the only permission this app needs.

https://github.com/flathub/flathub/pull/4391

https://github.com/Nokse22/inspector