### PR TITLE
Add flatpak-spawn exception for DoorKnocker

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1631,5 +1631,8 @@
     },
     "io.github.Youda008.DoomRunner": {
         "finish-args-flatpak-spawn-access": "Needed to execute external game engines"
+    },
+    "xyz.tytanium.DoorKnocker": {
+        "finish-args-flatpak-spawn-access": "Required to get/check xdg-desktop-portal version"
     }
 }


### PR DESCRIPTION
Related to and needed for https://github.com/flathub/flathub/pull/4436

DoorKnocker relies on xdg-desktop-portal version to list which portal is unavailable because of a missing implementation or because xdg-desktop-portal version does not provide the portal.