### PR TITLE
Add flatpak-spawn exception for Multiplex

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1637,5 +1637,8 @@
     },
     "page.codeberg.JakobDev.jdDBusDebugger": {
         "finish-args-arbitrary-dbus-access": "It's a D-Bus Debugger"
+    },
+    "com.pojtinger.felicitas.Multiplex": {
+        "finish-args-flatpak-spawn-access": "Needed to execute external copies of MPV and control them via IPC"
     }
 }


### PR DESCRIPTION
This adds a `flatpak-spawn` exception for Multiplex. More details as to why this is required, the background behind why this was chosen over other methods such as embedding MPV etc. can be found here: https://github.com/flathub/flathub/pull/4479