### PR TITLE
Add spawn exception for turtle

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1640,5 +1640,8 @@
     },
     "com.pojtinger.felicitas.Multiplex": {
         "finish-args-flatpak-spawn-access": "Needed to execute external copies of MPV and control them via IPC"
+    },
+    "de.philippun1.turtle": {
+        "finish-args-flatpak-spawn-access": "Needed to spawn diff tool to compare files"
     }
 }


### PR DESCRIPTION
Turtle is a development tool and needs to spawn a diff tool to compare files.