### PR TITLE
Add "finish-args-contains-both-x11-and-wayland" exception for Anki Flatpak (net.ankiweb.Anki)

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1135,6 +1135,9 @@
     "io.stoplight.studio": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "net.ankiweb.Anki": {
+        "finish-args-contains-both-x11-and-wayland": "Required for Wayland support in tandem with X11"
+    },
     "net.cozic.joplin_desktop": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },


### PR DESCRIPTION
Required for flathub/net.ankiweb.Anki#113