### PR TITLE
Add net.nokyan.Resources

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1648,5 +1648,8 @@
     },
     "io.github.jean28518.Linux-Assistant": {
         "finish-args-flatpak-spawn-access": "Required to get information about the os and execute host commands e.g. like the package managers"
+    },
+    "net.nokyan.Resources": {
+        "finish-args-flatpak-spawn-access": "Required to spawn a small executable dedicated to finding running processes in /proc"
     }
 }


### PR DESCRIPTION
Resources is a process and system resources viewer that needs to flatpak-spawn an executable dedicated to finding running processes in /proc in order to work properly.