### PR TITLE
Add exceptions for org.godotengine.GodotSharp and org.godotengine.Godot3Sharp to allow both to use external code editors

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1204,6 +1204,12 @@
     "org.godotengine.Godot3": {
         "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
     },
+    "org.godotengine.Godot3Sharp": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
+    },
+    "org.godotengine.GodotSharp": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
+    },
     "org.hydrogenmusic.Hydrogen": {
         "flathub-json-skip-appstream-check": "appstream file has GPL license, upstream hasn't fixed it"
     },


### PR DESCRIPTION
This is for these PRs in [flathub/flathub](https://github.com/flathub/flathub/), to allow both apps to use external editors using access to `flatpak-spawn`: https://github.com/flathub/flathub/pull/4594 and https://github.com/flathub/flathub/pull/4595