### PR TITLE
Add io.github.everestapi.Olympus exception

### DIFF
--- a/flatpak_builder_lint/builddir.py
+++ b/flatpak_builder_lint/builddir.py
@@ -68,9 +68,6 @@ def parse_metadata(ini: str) -> dict:
     if "sockets" in permissions:
         permissions["socket"] = permissions.pop("sockets")
 
-    if "x11" in permissions["socket"] and "fallback-x11" in permissions["socket"]:
-        permissions["socket"].remove("x11")
-
     if "devices" in permissions:
         permissions["device"] = permissions.pop("devices")
 

--- a/flatpak_builder_lint/builddir.py
+++ b/flatpak_builder_lint/builddir.py
@@ -68,6 +68,9 @@ def parse_metadata(ini: str) -> dict:
     if "sockets" in permissions:
         permissions["socket"] = permissions.pop("sockets")
 
+    if "x11" in permissions["socket"] and "fallback-x11" in permissions["socket"]:
+        permissions["socket"].remove("x11")
+
     if "devices" in permissions:
         permissions["device"] = permissions.pop("devices")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flatpak_builder_lint"
-version = "2.0.6"
+version = "2.0.8"
 description = "A linter for flatpak-builder manifests"
 authors = ["Bartłomiej Piotrowski <b@bpiotrowski.pl>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flatpak_builder_lint"
-version = "2.0.8"
+version = "2.0.6"
 description = "A linter for flatpak-builder manifests"
 authors = ["Bartłomiej Piotrowski <b@bpiotrowski.pl>"]
 license = "MIT"


### PR DESCRIPTION
This follow https://github.com/flathub/flathub/pull/4591#discussion_r1352413075. `flatpak-spawn` is needed because the Celeste mod manager Olympus needs to be able to launch the modded game (Celeste) outside of the flatpak sandbox. 
The corresponding PR : https://github.com/flathub/flathub/pull/4591