### PR TITLE
Add flatpak-spawn exception for com.obsproject.Studio

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1654,5 +1654,8 @@
     },
     "io.github.everestapi.Olympus": {
         "finish-args-flatpak-spawn-access": "Required to be able to launch the modded Celeste game outside of the flatpak sandbox"
+    },
+    "com.obsproject.Studio": {
+        "finish-args-flatpak-spawn-access": "Required for the virtual camera feature"
     }
 }


### PR DESCRIPTION
Until we reimplement virtual camera using PipeWire, this exception is needed.