### PR TITLE
schema: Add 'secret-env' and 'secret-args'

### DIFF
--- a/flatpak_builder_lint/staticfiles/flatpak-manifest.schema.json
+++ b/flatpak_builder_lint/staticfiles/flatpak-manifest.schema.json
@@ -89,6 +89,14 @@
           },
           "additionalProperties": false
         },
+        "secret-env": {
+          "description": "This is a array defining which host environment variables is transfered to build-commands or post-install environment.",
+          "type": "array",
+          "items": {
+            "description": "Host environment variable to transfer.",
+            "type": "string"
+          }
+        },
         "build-args": {
           "description": "This is an array containing extra options to pass to flatpak build.",
           "type": "array",
@@ -299,6 +307,14 @@
           "type": "array",
           "items": {
             "description": "Option that will be passed to configure.",
+            "type": "string"
+          }
+        },
+        "secret-opts": {
+          "description": "This is an array of options that will be passed to configure, meant to be used to pass secrets through host environment variables. Put the option with an environment variables and will be resolved beforehand. '-DSECRET_ID=$CI_SECRET'",
+          "type": "array",
+          "items": {
+            "description": "Extra options to pass to configure.",
             "type": "string"
           }
         },


### PR DESCRIPTION
These are defined in flatpak-builder's schema as well.

Closes: https://github.com/flathub/flatpak-builder-lint/issues/196