### PR TITLE
Add exception for org.godotengine.Godot3Sharp to allow it to use external code editors

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1204,6 +1204,9 @@
     "org.godotengine.Godot3": {
         "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
     },
+    "org.godotengine.Godot3Sharp": {
+        "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
+    },
     "org.godotengine.GodotSharp": {
         "finish-args-flatpak-spawn-access": "the app requires flatpak-spawn access to allow external code editors to be used with it"
     },


### PR DESCRIPTION
This is for https://github.com/flathub/flathub/pull/4595