### PR TITLE
Add wildcard exception for QtWebengine baseapp

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1665,5 +1665,8 @@
     },
     "engineer.atlas.Nyxt": {
         "finish-args-flatpak-spawn-access": "Required access to external tools since Nyxt ecosystem expects to rely heavily on them"
+    },
+    "io.qt.qtwebengine.BaseApp": {
+        "*": "This is a baseapp"
     }
 }


### PR DESCRIPTION
I haven't imported all the baseapps but I can do so if needed.

https://github.com/flathub/io.qt.qtwebengine.BaseApp/pull/323