### PR TITLE
Add exception for gg.minion.Minion

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1449,6 +1449,9 @@
     "gg.guilded.Guilded": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "gg.minion.Minion": {
+        "finish-args-unnecessary-xdg-data-access": "This application manages AddOns in folders of game launchers and/or the folders within wine prefixes."
+    },
     "il.co.ravkavonline.RavKavOnline": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
[Minion](https://github.com/flathub/gg.minion.Minion/) is an application / manager for AddOns in Elder Scrolls Online (ESO) and World of Warcraft (WoW).

It is the primary manager for ESO on all platforms. 

The default location for Steam compadata is within `xdg-data/Steam` and Minions needs to access it.

It can access `~/.local/share/Steam` without this PR but `xdg-data/Steam` would be better practice.

This has 3.5k downloads already <strike>, is in the process of being maintained by the actual owner and has been up for half a year already</strike>.

![image](https://github.com/flathub/flatpak-builder-lint/assets/30195425/d133dffb-0434-4bdd-b77f-dc96a5a24aa4)

Here's a quick explanation on Linux about the application and small usage/setup example where it can bee seen that `xdg-data/Steam` could be accessed on a steamdeck (or native steam installation): https://www.youtube.com/watch?v=Xka0UalSjY0