### PR TITLE
Add xdg-config for org.gimp.GIMP.

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1512,6 +1512,9 @@
     "org.freefilesync.FreeFileSync": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "org.gimp.GIMP": {
+        "finish-args-unnecessary-xdg-config-access": "The option was created for us originally. See #328"
+    },
     "org.geogebra.GeoGebra": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
This permission was initially added for our use case (or at least partly, maybe others were asking too).
See: https://github.com/flatpak/flatpak/issues/328#issuecomment-260565160

We are actually considering dropping this for GIMP 3. But for the 2.10 series and the 2.99 development series, we need to keep continuity. We cannot suddenly break everyone's configuration in the middle of a release series.

Thanks!