### PR TITLE
Revert "Better check for xdg-dir access"

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -1,4 +1,3 @@
-import re
 from collections import defaultdict
 from typing import Optional, Set
 
@@ -25,12 +24,11 @@ class FinishArgsCheck(Check):
             self.errors.add("finish-args-fallback-x11-without-wayland")
 
         for xdg_dir in ["xdg-data", "xdg-config", "xdg-cache"]:
-            regexp_arbitrary = f"^{xdg_dir}(:(create|rw|ro)?)?$"
-            regexp_unnecessary = f"^{xdg_dir}(\\/.*)?(:(create|rw|ro)?)?$"
+            if xdg_dir in finish_args["filesystem"]:
+                self.errors.add(f"finish-args-arbitrary-{xdg_dir}-access")
+
             for fs in finish_args["filesystem"]:
-                if re.match(regexp_arbitrary, fs):
-                    self.errors.add(f"finish-args-arbitrary-{xdg_dir}-access")
-                elif re.match(regexp_unnecessary, fs):
+                if fs.startswith(f"{xdg_dir}/") and fs.endswith(":create"):
                     self.errors.add(f"finish-args-unnecessary-{xdg_dir}-access")
 
         if "home" in finish_args["filesystem"] and "host" in finish_args["filesystem"]:

--- a/tests/manifests/finish_args.json
+++ b/tests/manifests/finish_args.json
@@ -8,7 +8,6 @@
         "--filesystem=xdg-config/autostart",
         "--filesystem=xdg-data",
         "--filesystem=xdg-data/foo:create",
-        "--filesystem=xdg-cache:create",
         "--own-name=org.flathub.finish_args",
         "--own-name=org.kde.StatusNotifierItem",
         "--socket=session-bus",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -62,7 +62,6 @@ def test_manifest_finish_args() -> None:
         "finish-args-arbitrary-autostart-access",
         "finish-args-arbitrary-dbus-access",
         "finish-args-arbitrary-xdg-data-access",
-        "finish-args-arbitrary-xdg-cache-access",
         "finish-args-broken-kde-tray-permission",
         "finish-args-flatpak-spawn-access",
         "finish-args-incorrect-dbus-gvfs",
@@ -90,6 +89,7 @@ def test_manifest_finish_args() -> None:
 def test_manifest_finish_args_issue_33() -> None:
     ret = run_checks("tests/manifests/own_name_substring.json")
     found_errors = set(ret["errors"])
+    print(found_errors)
     assert "finish-args-unnecessary-appid-own-name" not in found_errors
 
     ret = run_checks("tests/manifests/own_name_substring2.json")


### PR DESCRIPTION
- this trigger in unexpected conditions and needs to be reworked

This reverts commit 7869b06fd6b70f6cf8d63860274aff9f8925c155.