### PR TITLE
Error on home paths starting with `/home`

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -49,6 +49,8 @@ class FinishArgsCheck(Check):
             ]:
                 if fs.startswith(f"/{resv_dir}"):
                     self.errors.add(f"finish-args-reserved-{resv_dir}")
+            if fs.startswith("/home") or fs.startswith("/var/home"):
+                self.errors.add("finish-args-absolute-home-path")
 
         if "home" in finish_args["filesystem"] and "host" in finish_args["filesystem"]:
             self.errors.add("finish-args-redundant-home-and-host")


### PR DESCRIPTION
flatpaks can't access something under /home/ and any such absolute path is wrong

man flatpak manifest https://man7.org/linux/man-pages/man5/flatpak-metadata.5.html

Only `home`, `home/path` because it is alias to `~/`, `~` and `~/path` are valid. None of them can start with `/home` which makes it an absolute path that either 

a) is privileged, b) is wrong or c) should be changed to any of above.

Found [1](https://github.com/flathub/net.studio08.xbplay/blob/99e77dcacbc7270fa0ed4846611392d511167895/net.studio08.xbplay.yml#L19), [2](https://github.com/flathub/com.github.qarmin.szyszka/blob/87cbb94001a768b067c4af8cc57cf375c128f658/com.github.qarmin.szyszka.yaml#L12)

`/var/home` has a symlink to `/home` inside the sandbox on atomic OSes.

Found [1](https://github.com/flathub/com.github.mtkennerly.ludusavi/blob/8b793d7ebe3d561d946053c7be3a4bc700e0b69b/com.github.mtkennerly.ludusavi.yaml#L21)