### PR TITLE
Create a blocklist of filesystem paths treated as errors

### DIFF
--- a/flatpak_builder_lint/checks/finish_args.py
+++ b/flatpak_builder_lint/checks/finish_args.py
@@ -31,6 +31,25 @@ class FinishArgsCheck(Check):
                 if fs.startswith(f"{xdg_dir}/") and fs.endswith(":create"):
                     self.errors.add(f"finish-args-unnecessary-{xdg_dir}-access")
 
+        for fs in finish_args["filesystem"]:
+            for resv_dir in [
+                ".flatpak-info",
+                "app",
+                "dev",
+                "etc",
+                "lib",
+                "lib32",
+                "lib64",
+                "proc",
+                "root",
+                "run/flatpak",
+                "run/host",
+                "sbin",
+                "usr",
+            ]:
+                if fs.startswith(f"/{resv_dir}"):
+                    self.errors.add(f"finish-args-reserved-{resv_dir}")
+
         if "home" in finish_args["filesystem"] and "host" in finish_args["filesystem"]:
             self.errors.add("finish-args-redundant-home-and-host")
 


### PR DESCRIPTION
Based on https://github.com/flatpak/flatpak/blob/9e58442804def3937081da9994b796bd79bbee43/common/flatpak-exports.c#L66-L76

https://github.com/flatpak/flatpak/blob/9e58442804def3937081da9994b796bd79bbee43/common/flatpak-exports.c#L51-L57

https://github.com/flatpak/flatpak/blob/9e58442804def3937081da9994b796bd79bbee43/common/flatpak-exports.c#L975-L1013

The manpage says `/sys` should not be needed, but I do see a difference with and without `filesystem=/sys`:

```
flatpak run --command=sh org.flatpak.Builder        
[📦 org.flatpak.Builder]$ ls /sys
block  bus  class  dev	devices

flatpak run --command=sh --filesystem=/sys org.flatpak.Builder 
[📦 org.flatpak.Builder]$ ls /sys/
block  bus  class  dev	devices  firmware  fs  hypervisor  kernel  module  power
```

These should be safe, I think

Usages I found: [1](https://github.com/flathub/org.gustavoperedo.FontDownloader/blob/8d049f0d3f2d923d2054ea529e683bcd1ded9bb5/org.gustavoperedo.FontDownloader.json#L14), [2](https://github.com/flathub/org.gabmus.hydrapaper/blob/18bfe5da559e0e29e6f60ae2cffdf00db0411335/org.gabmus.hydrapaper.json#L16), [3](https://github.com/flathub/org.linux_hardware.hw-probe/blob/04888b09ab8deb8258b307a1169ae788388f578f/org.linux_hardware.hw-probe.yaml#L12)