### PR TITLE
Add org.ultimatepp.TheIDE to the exception list (finish-args-flatpak-spawn-access)

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1257,6 +1257,9 @@
     "org.texstudio.TeXstudio": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
+    "org.ultimatepp.TheIDE": {
+        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+    },
     "org.vim.Vim": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },

--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1258,7 +1258,7 @@
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"
     },
     "org.ultimatepp.TheIDE": {
-        "finish-args-flatpak-spawn-access": "the app predates this linter rule"
+        "finish-args-flatpak-spawn-access": "required to execute various host binaries, including compiler, debugger, and git within the application"
     },
     "org.vim.Vim": {
         "finish-args-flatpak-spawn-access": "the app predates this linter rule"


### PR DESCRIPTION
In order to make proper Flatpak for TheIDE there is a need to use "--talk-name=org.freedesktop.Flatpak" permision. More details why it is need can be found in my [comment](https://github.com/flathub/flathub/pull/4778#issuecomment-1854030106) in the PR to main flathub repository.