### PR TITLE
Print appstream validation errors

### DIFF
--- a/flatpak_builder_lint/checks/__init__.py
+++ b/flatpak_builder_lint/checks/__init__.py
@@ -18,6 +18,7 @@ class Check(metaclass=CheckMeta):
     warnings: Set[Optional[str]] = set()
     errors: Set[Optional[str]] = set()
     jsonschema: Set[Optional[str]] = set()
+    appstream: Set[Optional[str]] = set()
     repo_primary_ref: Optional[str] = None
 
     def _populate_ref(self, repo: str) -> None:

--- a/flatpak_builder_lint/checks/metainfo.py
+++ b/flatpak_builder_lint/checks/metainfo.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 from typing import Optional
 
@@ -45,6 +46,10 @@ class MetainfoCheck(Check):
                     appinfo_validation = appstream.validate(metainfo_path)
                     if appinfo_validation["returncode"] != 0:
                         self.errors.add("appstream-failed-validation")
+                        for err in appinfo_validation["stderr"].split(":", 1)[1:]:
+                            self.appstream.add(err.strip())
+                        for out in appinfo_validation["stdout"].splitlines()[1:]:
+                            self.appstream.add(re.sub("^\u2022", "", out).strip())
 
         if not (skip_icons_check or skip_appstream_check):
             if not os.path.exists(icon_path):

--- a/flatpak_builder_lint/cli.py
+++ b/flatpak_builder_lint/cli.py
@@ -76,6 +76,8 @@ def run_checks(
         results["warnings"] = list(warnings)
     if jsonschema := checks.Check.jsonschema:
         results["jsonschema"] = list(jsonschema)
+    if appstream := checks.Check.appstream:
+        results["appstream"] = list(appstream)
 
     if enable_exceptions:
         exceptions = None


### PR DESCRIPTION
This is an attempt to hopefully make the error a bit more readable, than printing the multiline output directly.

```
{
    "details": [
        "attribute-missing     : <release> has no timestamp",
        "tag-missing           : <content_rating> required [use https://odrs.gnome.org/oars]"
    ]
}
```
stderr is fail-safe, for invalid XMLs which stops at first failure eg. `"failed to parse com.example.app.metainfo.xml: Error on line 31 char 13: Element “component” was closed, but the currently open element is “summary”` (compose from flatpak-builder will fail before linter here)

I assume the first line will always be the filename/filepath from validation, so I strip that because its position gets messed up.