### PR TITLE
Add xdg-data exception for com.calibre_ebook.calibre

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1677,6 +1677,9 @@
         "finish-args-flatpak-spawn-access": "Run strace on the Host",
         "finish-args-unnecessary-xdg-data-access": "Needs to read desktop files"
     },
+    "com.calibre_ebook.calibre": {
+        "finish-args-unnecessary-xdg-data-access": "Needs direct trash access, doesn't use portal"
+    },
     "com.riverbankcomputing.PyQt.BaseApp": {
         "*": "This is a baseapp"
     },


### PR DESCRIPTION
This is required for trash access because app doesn't use trash portal.

See https://github.com/flathub/com.calibre_ebook.calibre/issues/83