### PR TITLE
Add com.adamcake.Bolt exceptions

### DIFF
--- a/flatpak_builder_lint/staticfiles/exceptions.json
+++ b/flatpak_builder_lint/staticfiles/exceptions.json
@@ -1308,6 +1308,10 @@
     "chat.tandem.Client": {
         "flathub-json-modified-publish-delay": "extra-data"
     },
+    "com.adamcake.Bolt": {
+        "finish-args-unnecessary-xdg-data-access": "individual games' window icons need to be downloaded and copied to xdg-data/icons as the user installs or updates them",
+        "finish-args-contains-both-x11-and-wayland": "some games support wayland and some don't"
+    },
     "com.adobe.Flash-Player-Projector": {
         "flathub-json-modified-publish-delay": "extra-data"
     },


### PR DESCRIPTION
Bolt needs these permissions:
- `finish-args-unnecessary-xdg-data-access` so that it can copy icons into `xdg-data/icons`, as the icons are downloaded with the game itself when the user chooses to install or update it. The icons need to be in that location so that DEs will pick them up and assign an the correct icon to the game window.
- `finish-args-contains-both-x11-and-wayland` as only one of the games launched by it supports Wayland, the others are Java-based and don't currently. The UI is Chromium based and therefore also doesn't support Wayland.
